### PR TITLE
Change relative Github URL to absolute

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -7,7 +7,7 @@ title: Shruthi Venkatesh
   
   <b> Twitter:</b>  <a href="https://twitter.com/svenkatesh382">@svenkatesh382</a> <br> <br> 
   
-  <b> Github:</b>  <a href="github.com/shruthi-venkatesh">shruthi-venkatesh</a> <br> <br> 
+  <b> Github:</b>  <a href="https://github.com/shruthi-venkatesh">shruthi-venkatesh</a> <br> <br> 
   
   <b> Office Address:</b>  <br> 
   Heinz College <br>


### PR DESCRIPTION
Fixes the Github contact link, which currently takes you to https://shruthi-venkatesh.github.io/contact/github.com/shruthi-venkatesh